### PR TITLE
Build on GNU/kFreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,9 @@ echo "###########################################" >> ./summary
 # CHECK Make
 
 case $host_type in
+   *-gnu*)
+	make_exe=make
+	;;
    *freebsd*)
 	make_exe=gmake
 	;;

--- a/configure.ac
+++ b/configure.ac
@@ -69,22 +69,18 @@ echo "###########################################" >> ./summary
 
 case $host_type in
    *freebsd*)
-	AC_CHECK_PROG(MAKEPROG,gmake,gmake,no)
-	if test "$MAKEPROG" == "no"
-	then
-	  AC_MSG_ERROR(Cannot find GNU gmake.)
-	fi
-	AC_SUBST(MAKEPROG,$MAKEPROG)
+	make_exe=gmake
 	;;
    *)
-	AC_CHECK_PROG(MAKEPROG,make,make,no)
-	if test "$MAKEPROG" == "no"
-	then
-	  AC_MSG_ERROR(Cannot find GNU make.)
-	fi
-	AC_SUBST(MAKEPROG,$MAKEPROG)
+	make_exe=make
 	;;
 esac
+AC_CHECK_PROG(MAKEPROG,$make_exe,$make_exe,no)
+if test "$MAKEPROG" == "no"
+then
+  AC_MSG_ERROR(Cannot find GNU make as $make_exe.)
+fi
+AC_SUBST(MAKEPROG,$MAKEPROG)
 
 ##########
 # CHECK OCaml an needed binaries


### PR DESCRIPTION
Factor out the `make` search code in `configure.ac`, and force the use of `make` on any GNU system.